### PR TITLE
Allow definition of AWS credential in service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,8 @@ yace_exporter_system_group: "yace-exp"
 yace_exporter_system_user: "yace-exp"
 yace_exporter_configuration: {}
 yace_exporter_debug: false
+
+# If defined add environnement variables for AWS credential in service definition
+#yace_exporter_aws_credentials:
+#  aws_access_key_id: xxxx
+#  aws_secret_access_key: xxxx

--- a/templates/yace_exporter.service.j2
+++ b/templates/yace_exporter.service.j2
@@ -10,6 +10,10 @@ User={{yace_exporter_system_user}}
 Group={{yace_exporter_system_group}}
 PermissionsStartOnly=true
 ExecReload=/bin/kill -HUP $MAINPID
+{% if yace_exporter_aws_credentials is defined %}
+Environment="AWS_ACCESS_KEY_ID={{ yace_exporter_aws_credentials.aws_access_key_id }}"
+Environment="AWS_SECRET_ACCESS_KEY={{ yace_exporter_aws_credentials.aws_secret_access_key }}"
+{% endif %}
 ExecStart=/usr/local/bin/yace          \
   -config.file=/etc/yace_exporter.yml \
   -listen-address={{ yace_exporter_web_listen_address }} {% if yace_exporter_debug | default(false) %} \


### PR DESCRIPTION
In AWS Go SDK, AWS credential can be defined throught ~/.aws/credential file (not possible because yace-exp user is defined as system user), IAM role on EC2 instance (not possible in my case because this exporter is not installed on a EC2 instance) or environnment variables.
This PR allow defintion of environnement variables in SystemD Service Unit.
Yoann